### PR TITLE
tests:Produce sorted policy with unique rules only

### DIFF
--- a/tests/make_policies.bash
+++ b/tests/make_policies.bash
@@ -48,7 +48,11 @@ do
 			"$generator" l=$l u=$u L=$L m=$m $I < $in | shuf > $outfile
 
 			#for merged policy make additionally sorted policy
-			test $m -eq 1 && cat $outfile | sort > "$outdir""$type""$l""sorted" || true
+			if [ $m -eq 0 ]
+			then
+				echo generating "$outdir""$type""$l""sorted"
+				cat $outfile | sort > "$outdir""$type""$l""sorted"
+			fi
 			done;
 		fi
 	done


### PR DESCRIPTION
Hi,
I've just noticed a bug on my scipt I made during rebasing and refactoring that caused the sorted policy to have redundant rules.
The idea was, that "sorted" policy has no redundancy (no merges). 
Please, pull this patch also.

Best regards,
Jan Cybulski
